### PR TITLE
Fix #10262

### DIFF
--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -64,9 +64,6 @@ namespace GitCommands
             private readonly bool _redirectOutput;
             private readonly bool _throwOnErrorExit;
 
-            private MemoryStream? _emptyStream;
-            private StreamReader? _emptyReader;
-
             private bool _disposed;
 
             public ProcessWrapper(string fileName,
@@ -212,14 +209,7 @@ namespace GitCommands
                         throw new InvalidOperationException("Process was not created with redirected output.");
                     }
 
-                    if (!_throwOnErrorExit)
-                    {
-                        return _process.StandardError;
-                    }
-
-                    _emptyStream ??= new();
-                    _emptyReader ??= new(_emptyStream);
-                    return _emptyReader;
+                    return _process.StandardError;
                 }
             }
 
@@ -261,9 +251,6 @@ namespace GitCommands
                 _process.Dispose();
 
                 _logOperation.NotifyDisposed();
-
-                _emptyReader?.Dispose();
-                _emptyStream?.Dispose();
             }
         }
 

--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -204,7 +204,7 @@ namespace GitCommands
             {
                 get
                 {
-                    if (!_redirectOutput && !_throwOnErrorExit)
+                    if (!_redirectOutput)
                     {
                         throw new InvalidOperationException("Process was not created with redirected output.");
                     }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10262 

## Proposed changes

- Actually get error output

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

- Git Extensions 33.33.33
- Build 10b59aa155ac73e0f4367e69fa2d717a301ceaf6
- Git 2.37.3.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 6.0.10
- DPI 96dpi (no scaling)
![image](https://user-images.githubusercontent.com/3629489/196041880-d4c3d21f-b427-4a32-8945-e55d5f1c1683.png)
```
Entering 'Externals/EasyHook'
Entering 'Externals/Git.hub'
Removing Git.hub/bin/
Removing Git.hub/obj/
Entering 'Externals/ICSharpCode.TextEditor'
Removing Project/bin/
Removing Project/obj/
Entering 'Externals/conemu-inside'
Removing ConEmuWinForms/bin/
Removing ConEmuWinForms/obj/
Removing .vs/
Removing BugReporter/BugReporter.csproj.user
Removing Externals/NetSpell.SpellChecker/bin/
Removing Externals/NetSpell.SpellChecker/obj/
Removing GitUI/GitUI.csproj.user
Removing IntegrationTests/UI.IntegrationTests/UI.IntegrationTests.csproj.user
Removing Plugins/Bitbucket/GitExtensions.Plugins.Bitbucket.csproj.user
Removing Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorIntegration.csproj.user
Removing Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsIntegration.csproj.user
Removing Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsIntegration.csproj.user
Removing Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityIntegration.csproj.user
Removing Plugins/CreateLocalBranches/GitExtensions.Plugins.CreateLocalBranches.csproj.user
Removing Plugins/DeleteUnusedBranches/GitExtensions.Plugins.DeleteUnusedBranches.csproj.user
Removing Plugins/FindLargeFiles/GitExtensions.Plugins.FindLargeFiles.csproj.user
Removing Plugins/GitFlow/GitExtensions.Plugins.GitFlow.csproj.user
Removing Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj.user
Removing Plugins/Gource/GitExtensions.Plugins.Gource.csproj.user
Removing Plugins/ProxySwitcher/GitExtensions.Plugins.ProxySwitcher.csproj.user
Removing Plugins/ReleaseNotesGenerator/GitExtensions.Plugins.ReleaseNotesGenerator.csproj.user
Removing Plugins/Statistics/GitImpact/GitExtensions.Plugins.GitImpact.csproj.user
Removing Plugins/Statistics/GitStatistics/GitExtensions.Plugins.GitStatistics.csproj.user
Removing ResourceManager/ResourceManager.csproj.user
Removing Setup/bin/
Removing UpgradeLog.htm
Removing artifacts/
MSBuild version 17.3.2+561848881 for .NET
  Determining projects to restore...
  Restored C:\git\gitextensions\Externals\NetSpell.SpellChecker\SpellChecker.csproj (in 244 ms).
  Restored C:\git\gitextensions\Externals\ICSharpCode.TextEditor\Project\ICSharpCode.TextEditor.csproj (in 243 ms).
  Restored C:\git\gitextensions\Externals\Git.hub\Git.hub\Git.hub.csproj (in 458 ms).
  Restored C:\git\gitextensions\Externals\conemu-inside\ConEmuWinForms\ConEmuWinForms.csproj (in 499 ms).
  Restored C:\git\gitextensions\Plugins\DeleteUnusedBranches\GitExtensions.Plugins.DeleteUnusedBranches.csproj (in 704 ms).
  Restored C:\git\gitextensions\Plugins\CreateLocalBranches\GitExtensions.Plugins.CreateLocalBranches.csproj (in 652 ms).
  Restored C:\git\gitextensions\BugReporter\BugReporter.csproj (in 1.69 sec).
  Restored C:\git\gitextensions\ResourceManager\ResourceManager.csproj (in 1.65 sec).
  Restored C:\git\gitextensions\Plugins\BuildServerIntegration\TeamCityIntegration\TeamCityIntegration.csproj (in 23 ms).
  Restored C:\git\gitextensions\Plugins\BuildServerIntegration\AzureDevOpsIntegration\AzureDevOpsIntegration.csproj (in 1.65 sec).
  Restored C:\git\gitextensions\Plugins\BuildServerIntegration\JenkinsIntegration\JenkinsIntegration.csproj (in 96 ms).
  Restored C:\git\gitextensions\Plugins\BuildServerIntegration\AppVeyorIntegration\AppVeyorIntegration.csproj (in 38 ms).
  Restored C:\git\gitextensions\Plugins\Bitbucket\GitExtensions.Plugins.Bitbucket.csproj (in 135 ms).
  Restored C:\git\gitextensions\UnitTests\Plugins\ReleaseNotesGenerator.Tests\ReleaseNotesGenerator.Tests.csproj (in 594 ms).
  Restored C:\git\gitextensions\UnitTests\GitExtUtils.Tests\GitExtUtils.Tests.csproj (in 2.35 sec).
  Restored C:\git\gitextensions\Plugins\BackgroundFetch\GitExtensions.Plugins.BackgroundFetch.csproj (in 22 ms).
  Restored C:\git\gitextensions\UnitTests\Plugins\BuildServerIntegration\AppVeyorIntegration.Tests\AppVeyorIntegration.Tests.csproj (in 2.35 sec).
  Restored C:\git\gitextensions\UnitTests\GitUI.Tests\GitUI.Tests.csproj (in 2.35 sec).
  Restored C:\git\gitextensions\UnitTests\Plugins\GitUIPluginInterfaces.Tests\GitUIPluginInterfaces.Tests.csproj (in 528 ms).
  Restored C:\git\gitextensions\UnitTests\ResourceManager.Tests\ResourceManager.Tests.csproj (in 607 ms).
  Restored C:\git\gitextensions\IntegrationTests\UI.IntegrationTests\UI.IntegrationTests.csproj (in 617 ms).
  Restored C:\git\gitextensions\GitExtUtils\GitExtUtils.csproj (in 5 ms).
  Restored C:\git\gitextensions\GitCommands\GitCommands.csproj (in 47 ms).
  Restored C:\git\gitextensions\GitUI\GitUI.csproj (in 58 ms).
  Restored C:\git\gitextensions\IntegrationTests\BugReporter.IntegrationTests\BugReporter.IntegrationTests.csproj (in 91 ms).
  Restored C:\git\gitextensions\Plugins\Gource\GitExtensions.Plugins.Gource.csproj (in 89 ms).
  Restored C:\git\gitextensions\Plugins\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj (in 43 ms).
  Restored C:\git\gitextensions\Plugins\AutoCompileSubmodules\GitExtensions.Plugins.AutoCompileSubmodules.csproj (in 77 ms).
  Restored C:\git\gitextensions\Plugins\GitHub3\GitExtensions.Plugins.GitHub3.csproj (in 18 ms).
  Restored C:\git\gitextensions\Plugins\GitFlow\GitExtensions.Plugins.GitFlow.csproj (in 53 ms).
  Restored C:\git\gitextensions\UnitTests\CommonTestUtils\CommonTestUtils.csproj (in 277 ms).
  Restored C:\git\gitextensions\Plugins\FindLargeFiles\GitExtensions.Plugins.FindLargeFiles.csproj (in 43 ms).
  Restored C:\git\gitextensions\UnitTests\Plugins\BuildServerIntegration\AzureDevOpsIntegration.Tests\AzureDevOpsIntegration.Tests.csproj (in 424 ms).
  Restored C:\git\gitextensions\UnitTests\BugReporter.Tests\BugReporter.Tests.csproj (in 147 ms).
  Restored C:\git\gitextensions\UnitTests\Plugins\DeleteUnusedBranches.Tests\DeleteUnusedBranches.Tests.csproj (in 427 ms).
  Restored C:\git\gitextensions\GitExtensions\GitExtensions.csproj (in 164 ms).
  Restored C:\git\gitextensions\UnitTests\GitCommands.Tests\GitCommands.Tests.csproj (in 421 ms).
  Restored C:\git\gitextensions\Plugins\Statistics\GitStatistics\GitExtensions.Plugins.GitStatistics.csproj (in 47 ms).
  Restored C:\git\gitextensions\Plugins\ReleaseNotesGenerator\GitExtensions.Plugins.ReleaseNotesGenerator.csproj (in 47 ms).
  Restored C:\git\gitextensions\TranslationApp\TranslationApp.csproj (in 99 ms).
  Restored C:\git\gitextensions\Plugins\Statistics\GitImpact\GitExtensions.Plugins.GitImpact.csproj (in 144 ms).
  Restored C:\git\gitextensions\Plugins\JiraCommitHintPlugin\GitExtensions.Plugins.JiraCommitHintPlugin.csproj (in 98 ms).
  Restored C:\git\gitextensions\Plugins\ProxySwitcher\GitExtensions.Plugins.ProxySwitcher.csproj (in 39 ms).
  SpellChecker -> C:\git\gitextensions\Externals\NetSpell.SpellChecker\bin\Debug\net6.0-windows\SpellChecker.dll
  Git.hub -> C:\git\gitextensions\Externals\Git.hub\Git.hub\bin\Debug\netstandard2.0\Git.hub.dll
C:\git\gitextensions\Externals\conemu-inside\ConEmuWinForms\ConEmuControl.cs(59,77): warning VSTHRD110: Observe the awaitable result of this method call by awaiting it, assigning to a variable, or passing it to another method. [C:\git\gitextensions\Externals\conemu-inside\ConEmuWinForms\ConEmuWinForms.csproj]
  ConEmuWinForms -> C:\git\gitextensions\Externals\conemu-inside\ConEmuWinForms\bin\net6.0-windows\ConEmuWinForms.dll
  GitExtUtils -> C:\git\gitextensions\artifacts\Debug\bin\GitExtUtils\net6.0-windows\GitExtUtils.dll
  GitUIPluginInterfaces -> C:\git\gitextensions\artifacts\Debug\bin\GitUIPluginInterfaces\net6.0-windows\GitUIPluginInterfaces.dll
  GitCommands -> C:\git\gitextensions\artifacts\Debug\bin\GitCommands\net6.0-windows\GitCommands.dll
  ResourceManager -> C:\git\gitextensions\artifacts\Debug\bin\ResourceManager\net6.0-windows\ResourceManager.dll
  GitExtensions.Plugins.CreateLocalBranches -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\CreateLocalBranches\GitExtensions.Plugins.CreateLocalBranches.dll
  AppVeyorIntegration -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\AppVeyorIntegration\AppVeyorIntegration.dll
  GitExtensions.Plugins.GitFlow -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\GitFlow\GitExtensions.Plugins.GitFlow.dll
  GitExtensions.Plugins.GitHub3 -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\GitHub3\GitExtensions.Plugins.GitHub3.dll
  GitExtensions.Plugins.AutoCompileSubmodules -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\AutoCompileSubmodules\GitExtensions.Plugins.AutoCompileSubmodules.dll
  GitExtensions.Plugins.BackgroundFetch -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\BackgroundFetch\GitExtensions.Plugins.BackgroundFetch.dll
  GitExtensions.Plugins.JiraCommitHintPlugin -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\JiraCommitHintPlugin\GitExtensions.Plugins.JiraCommitHintPlugin.dll
  GitExtensions.Plugins.ReleaseNotesGenerator -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\ReleaseNotesGenerator\GitExtensions.Plugins.ReleaseNotesGenerator.dll
  AzureDevOpsIntegration -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\AzureDevOpsIntegration\AzureDevOpsIntegration.dll
  GitExtensions.Plugins.ProxySwitcher -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\ProxySwitcher\GitExtensions.Plugins.ProxySwitcher.dll
  JenkinsIntegration -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\JenkinsIntegration\JenkinsIntegration.dll
  TeamCityIntegration -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\TeamCityIntegration\TeamCityIntegration.dll
  GitExtensions.Plugins.GitImpact -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\GitImpact\GitExtensions.Plugins.GitImpact.dll
  BugReporter -> C:\git\gitextensions\artifacts\Debug\bin\BugReporter\net6.0-windows\BugReporter.dll
  GitExtensions.Plugins.Bitbucket -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\Bitbucket\GitExtensions.Plugins.Bitbucket.dll
  ICSharpCode.TextEditor -> C:\git\gitextensions\Externals\ICSharpCode.TextEditor\Project\bin\Release\net6.0-windows\ICSharpCode.TextEditor.dll
  GitUI -> C:\git\gitextensions\artifacts\Debug\bin\GitUI\net6.0-windows\GitUI.dll
  GitExtensions.Plugins.DeleteUnusedBranches -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\DeleteUnusedBranches\GitExtensions.Plugins.DeleteUnusedBranches.dll
  TranslationApp -> C:\git\gitextensions\artifacts\Debug\bin\TranslationApp\net6.0-windows\TranslationApp.dll
  GitExtensions.Plugins.Gource -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\Gource\GitExtensions.Plugins.Gource.dll
  GitExtensions.Plugins.FindLargeFiles -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\FindLargeFiles\GitExtensions.Plugins.FindLargeFiles.dll
  GitExtensions.Plugins.GitStatistics -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\GitStatistics\GitExtensions.Plugins.GitStatistics.dll
  GitExtensions -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\GitExtensions.dll
  CommonTestUtils -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\CommonTestUtils\net6.0-windows\CommonTestUtils.dll
  DeleteUnusedBranches.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\DeleteUnusedBranches.Tests\net6.0-windows\DeleteUnusedBranches.Tests.dll
  AzureDevOpsIntegration.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\AzureDevOpsIntegration.Tests\net6.0-windows\AzureDevOpsIntegration.Tests.dll
  GitUIPluginInterfaces.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\GitUIPluginInterfaces.Tests\net6.0-windows\GitUIPluginInterfaces.Tests.dll
  ResourceManager.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\ResourceManager.Tests\net6.0-windows\ResourceManager.Tests.dll
  BugReporter.IntegrationTests -> C:\git\gitextensions\artifacts\Debug\bin\tests\IntegrationTests\BugReporter.IntegrationTests\net6.0-windows\BugReporter.IntegrationTests.dll
  AppVeyorIntegration.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\AppVeyorIntegration.Tests\net6.0-windows\AppVeyorIntegration.Tests.dll
  BugReporter.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\BugReporter.Tests\net6.0-windows\BugReporter.Tests.dll
  ReleaseNotesGenerator.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\ReleaseNotesGenerator.Tests\net6.0-windows\ReleaseNotesGenerator.Tests.dll
  GitCommands.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\GitCommands.Tests\net6.0-windows\GitCommands.Tests.dll
  GitExtUtils.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\GitExtUtils.Tests\net6.0-windows\GitExtUtils.Tests.dll
  UI.IntegrationTests -> C:\git\gitextensions\artifacts\Debug\bin\tests\IntegrationTests\UI.IntegrationTests\net6.0-windows\UI.IntegrationTests.dll
  GitUI.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\GitUI.Tests\net6.0-windows\GitUI.Tests.dll

Build succeeded.

C:\git\gitextensions\Externals\conemu-inside\ConEmuWinForms\ConEmuControl.cs(59,77): warning VSTHRD110: Observe the awaitable result of this method call by awaiting it, assigning to a variable, or passing it to another method. [C:\git\gitextensions\Externals\conemu-inside\ConEmuWinForms\ConEmuWinForms.csproj]
    1 Warning(s)
    0 Error(s)

Time Elapsed 00:01:10.30
C:\git\gitextensions\scripts\..\artifacts
Starting C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\GitExtensions.exe
Current Commit: 10b59aa155ac73e0f4367e69fa2d717a301ceaf6
Bad Commit
Tag verification in gpg tab only shows tag names and not the verification message.
```

### After

- Git Extensions 33.33.33
- Build 94f3f45e74fcbc37e440ee919879ee91594e2d49
- Git 2.37.3.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 6.0.10
- DPI 96dpi (no scaling)
![image](https://user-images.githubusercontent.com/3629489/196042150-95214a02-00f8-47c9-ad11-a98aa69d0559.png)

```
Entering 'Externals/EasyHook'
Entering 'Externals/Git.hub'
Removing Git.hub/bin/
Removing Git.hub/obj/
Entering 'Externals/ICSharpCode.TextEditor'
Removing Project/bin/
Removing Project/obj/
Entering 'Externals/conemu-inside'
Removing ConEmuWinForms/bin/
Removing ConEmuWinForms/obj/
Removing Externals/NetSpell.SpellChecker/bin/
Removing Externals/NetSpell.SpellChecker/obj/
Removing artifacts/
MSBuild version 17.3.2+561848881 for .NET
  Determining projects to restore...
  Restored C:\git\gitextensions\Plugins\Statistics\GitStatistics\GitExtensions.Plugins.GitStatistics.csproj (in 1.14 sec).
  Restored C:\git\gitextensions\ResourceManager\ResourceManager.csproj (in 1.14 sec).
  Restored C:\git\gitextensions\Plugins\Statistics\GitImpact\GitExtensions.Plugins.GitImpact.csproj (in 1.14 sec).
  Restored C:\git\gitextensions\UnitTests\Plugins\DeleteUnusedBranches.Tests\DeleteUnusedBranches.Tests.csproj (in 1.15 sec).
  Restored C:\git\gitextensions\UnitTests\Plugins\BuildServerIntegration\AzureDevOpsIntegration.Tests\AzureDevOpsIntegration.Tests.csproj (in 1.15 sec).
  Restored C:\git\gitextensions\Plugins\JiraCommitHintPlugin\GitExtensions.Plugins.JiraCommitHintPlugin.csproj (in 1.14 sec).
  Restored C:\git\gitextensions\Plugins\ProxySwitcher\GitExtensions.Plugins.ProxySwitcher.csproj (in 1.14 sec).
  Restored C:\git\gitextensions\Plugins\ReleaseNotesGenerator\GitExtensions.Plugins.ReleaseNotesGenerator.csproj (in 1.14 sec).
  Restored C:\git\gitextensions\Plugins\CreateLocalBranches\GitExtensions.Plugins.CreateLocalBranches.csproj (in 56 ms).
  Restored C:\git\gitextensions\UnitTests\ResourceManager.Tests\ResourceManager.Tests.csproj (in 95 ms).
  Restored C:\git\gitextensions\UnitTests\Plugins\ReleaseNotesGenerator.Tests\ReleaseNotesGenerator.Tests.csproj (in 161 ms).
  Restored C:\git\gitextensions\Plugins\DeleteUnusedBranches\GitExtensions.Plugins.DeleteUnusedBranches.csproj (in 121 ms).
  Restored C:\git\gitextensions\UnitTests\GitExtUtils.Tests\GitExtUtils.Tests.csproj (in 187 ms).
  Restored C:\git\gitextensions\UnitTests\Plugins\BuildServerIntegration\AppVeyorIntegration.Tests\AppVeyorIntegration.Tests.csproj (in 188 ms).
  Restored C:\git\gitextensions\UnitTests\GitUI.Tests\GitUI.Tests.csproj (in 193 ms).
  Restored C:\git\gitextensions\Plugins\BuildServerIntegration\JenkinsIntegration\JenkinsIntegration.csproj (in 37 ms).
  Restored C:\git\gitextensions\Plugins\BuildServerIntegration\TeamCityIntegration\TeamCityIntegration.csproj (in 36 ms).
  Restored C:\git\gitextensions\Plugins\BuildServerIntegration\AppVeyorIntegration\AppVeyorIntegration.csproj (in 35 ms).
  Restored C:\git\gitextensions\UnitTests\Plugins\GitUIPluginInterfaces.Tests\GitUIPluginInterfaces.Tests.csproj (in 187 ms).
  Restored C:\git\gitextensions\Plugins\Bitbucket\GitExtensions.Plugins.Bitbucket.csproj (in 47 ms).
  Restored C:\git\gitextensions\Plugins\BuildServerIntegration\AzureDevOpsIntegration\AzureDevOpsIntegration.csproj (in 28 ms).
  Restored C:\git\gitextensions\GitExtUtils\GitExtUtils.csproj (in 14 ms).
  Restored C:\git\gitextensions\Plugins\AutoCompileSubmodules\GitExtensions.Plugins.AutoCompileSubmodules.csproj (in 61 ms).
  Restored C:\git\gitextensions\Plugins\BackgroundFetch\GitExtensions.Plugins.BackgroundFetch.csproj (in 22 ms).
  Restored C:\git\gitextensions\GitUI\GitUI.csproj (in 91 ms).
  Restored C:\git\gitextensions\GitCommands\GitCommands.csproj (in 55 ms).
  Restored C:\git\gitextensions\GitExtensions\GitExtensions.csproj (in 123 ms).
  Restored C:\git\gitextensions\IntegrationTests\BugReporter.IntegrationTests\BugReporter.IntegrationTests.csproj (in 147 ms).
  Restored C:\git\gitextensions\UnitTests\CommonTestUtils\CommonTestUtils.csproj (in 205 ms).
  Restored C:\git\gitextensions\TranslationApp\TranslationApp.csproj (in 192 ms).
  Restored C:\git\gitextensions\Plugins\Gource\GitExtensions.Plugins.Gource.csproj (in 179 ms).
  Restored C:\git\gitextensions\IntegrationTests\UI.IntegrationTests\UI.IntegrationTests.csproj (in 262 ms).
  Restored C:\git\gitextensions\Plugins\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj (in 47 ms).
  Restored C:\git\gitextensions\Plugins\GitFlow\GitExtensions.Plugins.GitFlow.csproj (in 42 ms).
  Restored C:\git\gitextensions\UnitTests\GitCommands.Tests\GitCommands.Tests.csproj (in 283 ms).
  Restored C:\git\gitextensions\Externals\NetSpell.SpellChecker\SpellChecker.csproj (in 3 ms).
  Restored C:\git\gitextensions\Externals\ICSharpCode.TextEditor\Project\ICSharpCode.TextEditor.csproj (in 17 ms).
  Restored C:\git\gitextensions\UnitTests\BugReporter.Tests\BugReporter.Tests.csproj (in 289 ms).
  Restored C:\git\gitextensions\Plugins\GitHub3\GitExtensions.Plugins.GitHub3.csproj (in 67 ms).
  Restored C:\git\gitextensions\Plugins\FindLargeFiles\GitExtensions.Plugins.FindLargeFiles.csproj (in 61 ms).
  Restored C:\git\gitextensions\BugReporter\BugReporter.csproj (in 30 ms).
  Restored C:\git\gitextensions\Externals\conemu-inside\ConEmuWinForms\ConEmuWinForms.csproj (in 54 ms).
  Restored C:\git\gitextensions\Externals\Git.hub\Git.hub\Git.hub.csproj (in 65 ms).
  Git.hub -> C:\git\gitextensions\Externals\Git.hub\Git.hub\bin\Debug\netstandard2.0\Git.hub.dll
C:\git\gitextensions\Externals\conemu-inside\ConEmuWinForms\ConEmuControl.cs(59,77): warning VSTHRD110: Observe the awaitable result of this method call by awaiting it, assigning to a variable, or passing it to another method. [C:\git\gitextensions\Externals\conemu-inside\ConEmuWinForms\ConEmuWinForms.csproj]
  SpellChecker -> C:\git\gitextensions\Externals\NetSpell.SpellChecker\bin\Debug\net6.0-windows\SpellChecker.dll
  ConEmuWinForms -> C:\git\gitextensions\Externals\conemu-inside\ConEmuWinForms\bin\net6.0-windows\ConEmuWinForms.dll
  GitExtUtils -> C:\git\gitextensions\artifacts\Debug\bin\GitExtUtils\net6.0-windows\GitExtUtils.dll
  GitUIPluginInterfaces -> C:\git\gitextensions\artifacts\Debug\bin\GitUIPluginInterfaces\net6.0-windows\GitUIPluginInterfaces.dll
  GitCommands -> C:\git\gitextensions\artifacts\Debug\bin\GitCommands\net6.0-windows\GitCommands.dll
  ResourceManager -> C:\git\gitextensions\artifacts\Debug\bin\ResourceManager\net6.0-windows\ResourceManager.dll
  GitExtensions.Plugins.ProxySwitcher -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\ProxySwitcher\GitExtensions.Plugins.ProxySwitcher.dll
  GitExtensions.Plugins.Bitbucket -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\Bitbucket\GitExtensions.Plugins.Bitbucket.dll
  GitExtensions.Plugins.JiraCommitHintPlugin -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\JiraCommitHintPlugin\GitExtensions.Plugins.JiraCommitHintPlugin.dll
  GitExtensions.Plugins.GitHub3 -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\GitHub3\GitExtensions.Plugins.GitHub3.dll
  AppVeyorIntegration -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\AppVeyorIntegration\AppVeyorIntegration.dll
  JenkinsIntegration -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\JenkinsIntegration\JenkinsIntegration.dll
  BugReporter -> C:\git\gitextensions\artifacts\Debug\bin\BugReporter\net6.0-windows\BugReporter.dll
  AzureDevOpsIntegration -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\AzureDevOpsIntegration\AzureDevOpsIntegration.dll
  TeamCityIntegration -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\TeamCityIntegration\TeamCityIntegration.dll
  GitExtensions.Plugins.BackgroundFetch -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\BackgroundFetch\GitExtensions.Plugins.BackgroundFetch.dll
  GitExtensions.Plugins.ReleaseNotesGenerator -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\ReleaseNotesGenerator\GitExtensions.Plugins.ReleaseNotesGenerator.dll
  GitExtensions.Plugins.AutoCompileSubmodules -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\AutoCompileSubmodules\GitExtensions.Plugins.AutoCompileSubmodules.dll
  GitExtensions.Plugins.CreateLocalBranches -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\CreateLocalBranches\GitExtensions.Plugins.CreateLocalBranches.dll
  GitExtensions.Plugins.GitImpact -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\GitImpact\GitExtensions.Plugins.GitImpact.dll
  GitExtensions.Plugins.GitFlow -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\GitFlow\GitExtensions.Plugins.GitFlow.dll
  ICSharpCode.TextEditor -> C:\git\gitextensions\Externals\ICSharpCode.TextEditor\Project\bin\Release\net6.0-windows\ICSharpCode.TextEditor.dll
  GitUI -> C:\git\gitextensions\artifacts\Debug\bin\GitUI\net6.0-windows\GitUI.dll
  GitExtensions.Plugins.GitStatistics -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\GitStatistics\GitExtensions.Plugins.GitStatistics.dll
  GitExtensions.Plugins.DeleteUnusedBranches -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\DeleteUnusedBranches\GitExtensions.Plugins.DeleteUnusedBranches.dll
  GitExtensions.Plugins.FindLargeFiles -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\FindLargeFiles\GitExtensions.Plugins.FindLargeFiles.dll
  GitExtensions.Plugins.Gource -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\Plugins\Gource\GitExtensions.Plugins.Gource.dll
  TranslationApp -> C:\git\gitextensions\artifacts\Debug\bin\TranslationApp\net6.0-windows\TranslationApp.dll
  GitExtensions -> C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\GitExtensions.dll
  CommonTestUtils -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\CommonTestUtils\net6.0-windows\CommonTestUtils.dll
  AppVeyorIntegration.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\AppVeyorIntegration.Tests\net6.0-windows\AppVeyorIntegration.Tests.dll
  BugReporter.IntegrationTests -> C:\git\gitextensions\artifacts\Debug\bin\tests\IntegrationTests\BugReporter.IntegrationTests\net6.0-windows\BugReporter.IntegrationTests.dll
  BugReporter.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\BugReporter.Tests\net6.0-windows\BugReporter.Tests.dll
  AzureDevOpsIntegration.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\AzureDevOpsIntegration.Tests\net6.0-windows\AzureDevOpsIntegration.Tests.dll
  GitUIPluginInterfaces.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\GitUIPluginInterfaces.Tests\net6.0-windows\GitUIPluginInterfaces.Tests.dll
  GitCommands.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\GitCommands.Tests\net6.0-windows\GitCommands.Tests.dll
  DeleteUnusedBranches.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\DeleteUnusedBranches.Tests\net6.0-windows\DeleteUnusedBranches.Tests.dll
  ReleaseNotesGenerator.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\ReleaseNotesGenerator.Tests\net6.0-windows\ReleaseNotesGenerator.Tests.dll
  ResourceManager.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\ResourceManager.Tests\net6.0-windows\ResourceManager.Tests.dll
  GitExtUtils.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\GitExtUtils.Tests\net6.0-windows\GitExtUtils.Tests.dll
  UI.IntegrationTests -> C:\git\gitextensions\artifacts\Debug\bin\tests\IntegrationTests\UI.IntegrationTests\net6.0-windows\UI.IntegrationTests.dll
  GitUI.Tests -> C:\git\gitextensions\artifacts\Debug\bin\tests\UnitTests\GitUI.Tests\net6.0-windows\GitUI.Tests.dll

Build succeeded.

C:\git\gitextensions\Externals\conemu-inside\ConEmuWinForms\ConEmuControl.cs(59,77): warning VSTHRD110: Observe the awaitable result of this method call by awaiting it, assigning to a variable, or passing it to another method. [C:\git\gitextensions\Externals\conemu-inside\ConEmuWinForms\ConEmuWinForms.csproj]
    1 Warning(s)
    0 Error(s)

Time Elapsed 00:00:50.45
C:\git\gitextensions\scripts\..\artifacts
Starting C:\git\gitextensions\artifacts\Debug\bin\GitExtensions\net6.0-windows\GitExtensions.exe
Current Commit: 94f3f45e74fcbc37e440ee919879ee91594e2d49
Good Commit
```

## Test methodology <!-- How did you ensure quality? -->


1.  saved this script as Bisect-Test.ps1 in scripts folder
```ps
Param([switch] $Force,
    [switch] $Run,
    [switch] $Build)


function Build() {
    $buildScript = Join-Path -Path $scriptsPath -ChildPath build.ps1
    
    git submodule update --init --recursive
    git submodule foreach --recursive git clean -x -d -f
    git clean -x -d -f --exclude="scripts/*Bisect*.ps1" --exclude="Bisect.log"

    if (Test-Path -Path $buildScript) {
        & $buildScript -rebuild -bn -b -restore
    }
    else {
        dotnet build
    }
}

function Test() {
    try {
        $artifacts = Join-Path -Path $scriptsPath -ChildPath ..\artifacts
        $artifacts
        $ge = Get-ChildItem -Path $artifacts -Name gitextensions.exe -Recurse | Select-Object -First 1
        $geFull = Join-Path -Path $artifacts -ChildPath $ge
        $geFull = Resolve-Path -Path $geFull
        if ( (Get-Item $geFull) -is [System.IO.DirectoryInfo]) {
            Write-Output "Untestable Commit.  Cannot find build output"
            exit 125; # See https://git-scm.com/docs/git-bisect/#_bisect_run
        }
        else {
            Write-Output "Starting $geFull"
            [console]::beep(2000, 500)
            Start-Process -Wait -FilePath $geFull -ArgumentList browse
        }
    }
   
    catch {
        Write-Output "Untestable Commit"
        Write-Output $_
        exit 125; # See https://git-scm.com/docs/git-bisect/#_bisect_run
    }
              
    $testResult = $Host.UI.PromptForChoice('Did it perform as expected?', 'Did Git Extensions behave as expected?', @('&Yes'; '&No', '&Unsure'), 0)
    Write-Output "Current Commit: $(git rev-parse HEAD)"
    if ($testResult -eq 0) {
        Write-Output "Good Commit"
        exit 0
    }
    elseif ($testResult -eq 1) {
        Write-Output "Bad Commit"
        $describe = Read-Host -Prompt "Describe failure"
        Write-Output $describe
        exit 1 
    }
    elseif ($testResult -eq 2) {
        Write-Output "Untestable Commit"
        $describe = Read-Host -Prompt "Describe why you can't test"
        Write-Output $describe
        exit 125; # See https://git-scm.com/docs/git-bisect/#_bisect_run
    }
}

function Run {

    $scriptsPath = Get-Location
    $scriptsPath = Join-Path $scriptsPath -ChildPath scripts
    $result = 0
    if (-not $Force) {
        $result = $Host.UI.PromptForChoice('Running git clean -xdf', 'Are you sure you want to proceed? This will delete all files that are new and not committed or staged.', @('&Yes'; '&No'), 1)
    }
    if ($result -eq 0) {
        try {
        
            if ($Build) {
                Build  
            }
            
        }
        catch {
            Write-Output "Error  $LASTEXITCODE"
            Write-Output $_
            exit 125; # See https://git-scm.com/docs/git-bisect/#_bisect_run
        }   
        Test
    }
    else {
        Write-Output "User aborted"
        exit -1
    }

}
    
if ($Run) {
    Run    
}


```
1. ran ```.\scripts\Bisect-Test.ps1 -Build -Run >Log.txt``` on each commit
1. Selected my commit that I tagged with a signed tag  and verified with screenshots

I DID NOT run tests.  But those will need to be confirmed.   
## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
